### PR TITLE
Fix __eq__ methods raising RecursionError

### DIFF
--- a/ordering/__init__.py
+++ b/ordering/__init__.py
@@ -67,6 +67,15 @@ class Ordering(Mapping[T, 'OrderingItem[T]']):
 
         return item in self._labels
 
+    def __eq__(self, other: object) -> bool:
+        if self is other:
+            return True
+        if not isinstance(other, Ordering):
+            return NotImplemented
+        if len(self) != len(other):
+            return False
+        return all(a == b for a, b in zip(self, other))
+
     def __iter__(self) -> Iterator[T]:
         item = self._successors[self._start]
 
@@ -114,8 +123,8 @@ class OrderingItem(Generic[T]):
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, OrderingItem):
-            return bool(self.item == other)
-        return self.ordering == other.ordering and self.item == other.item
+            return self.item == other
+        return self.item == other.item and self.ordering == other.ordering
 
     def __lt__(self, other: 'OrderingItem[T]') -> bool:
         return self.ordering.compare(self.item, other.item)

--- a/tests/test_comparisons.py
+++ b/tests/test_comparisons.py
@@ -34,3 +34,21 @@ class TestComparisons(TestCase):
             sorted(range(3), key=self.ordering),  # type:ignore # https://github.com/python/mypy/issues/797
             [2, 0, 1]
         )
+
+    def test_ordering_equality(self) -> None:
+        self.assertEqual(self.ordering, self.ordering)
+        self.assertEqual(self.ordering, Ordering[int](self.ordering_list))
+
+    def test_ordering_inequality(self) -> None:
+        self.assertNotEqual(self.ordering, Ordering[int]())
+        self.assertNotEqual(self.ordering, Ordering[int](self.ordering_list[::-1]))
+
+    def test_ordering_item_equality(self) -> None:
+        for a in self.ordering:
+            with self.subTest(a=a):
+                self.assertEqual(self.ordering[a], self.ordering[a])
+
+    def test_ordering_item_inequality(self) -> None:
+        for a, b in combinations(self.ordering, 2):
+            with self.subTest(a=a, b=b):
+                self.assertNotEqual(self.ordering[a], self.ordering[b])


### PR DESCRIPTION
Override the `Ordering.__eq__` method, as the inherited supermethod
(from Mapping) compares both the keys and values. That is not only the
elements of the Ordering, but also their associated OrderingItems are
compared, which in turn requires the Orderings associated with said
OrderingItems to be compared, resulting in infinite recursion.

Tweak order of comparison in `OrderingItem.__eq__` to perform the
(slower) comparison of the `ordering` attributes if and only if the
(faster) comparison of the `item` attributes is True.

Remove unnecessary `bool()` call in `OrderingItem.__eq__`.

Add unit tests to for checking equality of Orderings or OrderingItems.