### PR TITLE
Disallow initialising from an iterable containing duplicates

### DIFF
--- a/ordering/__init__.py
+++ b/ordering/__init__.py
@@ -1,6 +1,6 @@
 from fractions import Fraction
 from functools import total_ordering
-from typing import Dict, Generic, Iterable, Iterator, List, Mapping, TypeVar, Union
+from typing import Collection, Dict, Generic, Iterable, Iterator, List, Mapping, TypeVar, Union
 
 from .utils import pairs
 
@@ -25,6 +25,7 @@ class Ordering(Mapping[T, 'OrderingItem[T]']):
         self._predecessors: Dict[_T, _T] = {}
 
         items: List[_T] = [self._start, *iterable, self._end]
+        self.assert_unique_items(items)
 
         for n, (a, b) in enumerate(pairs(items)):
             self._labels[a] = Fraction(n, len(items) - 1)
@@ -102,6 +103,14 @@ class Ordering(Mapping[T, 'OrderingItem[T]']):
     def assert_new_item(self, item: T) -> None:
         if item in self:
             raise KeyError("Ordering {} already contains {}".format(self, item))
+
+    @classmethod
+    def assert_unique_items(cls, items: Collection[_T]) -> None:
+        if len(items) > len(set(items)):
+            d: Dict[_T, bool] = {}
+            duplicates = [i for i in items if i in d or d.setdefault(i, False)]
+            raise ValueError('attempt to create {} containing duplicate items: {}'
+                             .format(cls.__name__, repr(duplicates)[1:-1]))
 
 
 @total_ordering

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -64,3 +64,15 @@ class TestOrderingBasic(TestCase):
         self.assertTrue(ordering.compare(2, 0))
         self.assertTrue(ordering.compare(2, 1))
         self.assertTrue(ordering.compare(0, 1))
+
+    def test_iterator_initialization_duplicates(self) -> None:
+        items_list: list = [[1, '1'], [1, 1+1j], ['a', b'a']]
+        for items in items_list:
+            with self.subTest(items=items):
+                self.assertListEqual(list(Ordering(items)), items)
+
+        items_list = [[1, 1], [1, 1.0], [1, 1+0j], [0, 0, 1], [0, 1, 0], [1, 0, 0], 'abracadabra']
+        for items in items_list:
+            with self.subTest(items=items):
+                with self.assertRaisesRegex(ValueError, 'attempt to create Ordering containing duplicate items'):
+                    Ordering(items)


### PR DESCRIPTION
Add `Ordering.assert_unique_items` class method to validate an iterable used to initialise an Ordering contains no duplicates, raising a ValueError otherwise.

Add unit test for rejecting duplicates at initialization.