### PR TITLE
Modify internals of Ordering.__iter__

### DIFF
--- a/ordering/__init__.py
+++ b/ordering/__init__.py
@@ -68,11 +68,13 @@ class Ordering(Mapping[T, 'OrderingItem[T]']):
         return item in self._labels
 
     def __iter__(self) -> Iterator[T]:
-        item = self._successors[self._start]
-
-        while not isinstance(item, _Sentinel):
+        successors = self._successors
+        item = successors[self._start]
+        end = self._end
+        while item is not end:
+            assert not isinstance(item, _Sentinel)
             yield item
-            item = self._successors[item]
+            item = successors[item]
 
     def __len__(self) -> int:
         return len(self._labels) - 2


### PR DESCRIPTION
Change while-loop test from isinstance to the more succinct identity comparison.

Extract needed attributes to local variables to avoid repeated lookups.

Move the redundant isinstance check to an assert statement, so it can be optionally ignored with the optimize flag, but remain useful as:

- a guard to potentially catch a corrupted internal state i.e. `Ordering._start` is in `_successors.values()`

- a means of providing type information to keep type checkers in order, without resorting to `# type: ignore`.