### PR TITLE
Improve errors raised by assert_* methods

### DIFF
--- a/ordering/__init__.py
+++ b/ordering/__init__.py
@@ -97,11 +97,11 @@ class Ordering(Mapping[T, 'OrderingItem[T]']):
 
     def assert_contains(self, item: _T) -> None:
         if item not in self:
-            raise KeyError("Ordering {} does not contain {}".format(self, item))
+            raise KeyError('{} does not contain {!r}'.format(type(self).__name__, item))
 
     def assert_new_item(self, item: T) -> None:
         if item in self:
-            raise KeyError("Ordering {} already contains {}".format(self, item))
+            raise ValueError('{} already contains {!r}'.format(type(self).__name__, item))
 
 
 @total_ordering


### PR DESCRIPTION
Change `Ordering.assert_new_item` to raise a ValueError instead of a KeyError, upon being called with a duplicate item.

Replace literal class name with dynamic lookup, so it will be correct for subclasses

Avoid printing the potentially large repr of an Ordering to the traceback, the traceback itself is enough to pinpoint which Ordering is raising the exception.

Add the repr conversion flag to the formatting of the errant item, to differentiate between e.g. 2 and '2'