### PR TITLE
Add repr methods for Ordering, OrderingItem & _Sentinel

### DIFF
--- a/ordering/__init__.py
+++ b/ordering/__init__.py
@@ -8,8 +8,12 @@ __all__ = ('Ordering', 'OrderingItem')
 
 
 class _Sentinel:
-    pass
+    def __set_name__(self, owner, name) -> None:
+        self.owner = owner
+        self.name = name
 
+    def __repr__(self) -> str:
+        return '{}.{}'.format(self.owner.__qualname__, self.name)
 
 T = TypeVar('T')
 _T = Union[T, _Sentinel]
@@ -103,6 +107,9 @@ class Ordering(Mapping[T, 'OrderingItem[T]']):
         if item in self:
             raise KeyError("Ordering {} already contains {}".format(self, item))
 
+    def __repr__(self) -> str:
+        return '{}({})'.format(type(self).__name__, list(self))
+
 
 @total_ordering
 class OrderingItem(Generic[T]):
@@ -125,3 +132,6 @@ class OrderingItem(Generic[T]):
 
     def insert_after(self, item: T) -> 'OrderingItem[T]':
         return self.ordering.insert_after(self.item, item)
+
+    def __repr__(self) -> str:
+        return '<{}: {!r}>'.format(type(self).__name__, self.item)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -64,3 +64,27 @@ class TestOrderingBasic(TestCase):
         self.assertTrue(ordering.compare(2, 0))
         self.assertTrue(ordering.compare(2, 1))
         self.assertTrue(ordering.compare(0, 1))
+
+    def test_ordering_empty_repr(self) -> None:
+        self.assertEqual(repr(Ordering()), 'Ordering([])')
+
+    def test_ordering_int_repr(self) -> None:
+        with self.subTest(items=(0,)):
+            self.assertEqual(repr(Ordering[int]((0,))), 'Ordering([0])')
+        with self.subTest(items=(0, 1)):
+            self.assertEqual(repr(Ordering[int]((0, 1))), 'Ordering([0, 1])')
+
+    def test_ordering_str_repr(self) -> None:
+        with self.subTest(items='a'):
+            self.assertEqual(repr(Ordering[str]('a')), "Ordering(['a'])")
+        with self.subTest(items='AaBb'):
+            self.assertEqual(repr(Ordering[str]('AaBb')), "Ordering(['A', 'a', 'B', 'b'])")
+
+    def test_ordering_item_repr_int(self) -> None:
+        ordering_item = Ordering[int]((2, 0, 1))[1]
+        self.assertEqual(repr(ordering_item), '<OrderingItem: 1>')
+
+    def test_ordering_item_repr_str(self) -> None:
+        ordering_item = Ordering[str]('cab')['a']
+        self.assertEqual(repr(ordering_item), "<OrderingItem: 'a'>")
+


### PR DESCRIPTION
Override default repr methods, to give friendlier output:

- an Orderings repr is now eval-able to return an equal object, e.g. `repr(Ordering([2, 0, 1])) == 'Ordering([2, 0, 1])'`;

- OrderingItems still use angle-brackets, but now display the item they reference e.g. `repr(Ordering([2])[2]) == '<OrderingItem: 2>'`;

- a _Sentinal's repr is the class attribute it is assigned to, e.g. `repr(Ordering._start) == 'Ordering._start'`.

Add basic unit tests for reprs of Ordering & OrderingItem