### PR TITLE
Modify Ordering.__contains__ type hinting

### DIFF
--- a/ordering/__init__.py
+++ b/ordering/__init__.py
@@ -61,7 +61,7 @@ class Ordering(Mapping[T, 'OrderingItem[T]']):
 
         return self._labels[left_item] < self._labels[right_item]
 
-    def __contains__(self, item: _T) -> bool:
+    def __contains__(self, item: object) -> bool:
         if isinstance(item, OrderingItem):
             return item.item in self._labels
 


### PR DESCRIPTION
Change type hint of `item` argument to `object`, as although `x in Ordering[T](...)` can only return True if `x` is an instance of `T` (or `_Sentinel`), it is still a valid comparison for `x` of all types.