### PR TITLE
Allow reflection of OrderingItem.__lt__

### DIFF
--- a/ordering/__init__.py
+++ b/ordering/__init__.py
@@ -117,7 +117,9 @@ class OrderingItem(Generic[T]):
             return bool(self.item == other)
         return self.ordering == other.ordering and self.item == other.item
 
-    def __lt__(self, other: 'OrderingItem[T]') -> bool:
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, OrderingItem):
+            return NotImplemented
         return self.ordering.compare(self.item, other.item)
 
     def insert_before(self, item: T) -> 'OrderingItem[T]':


### PR DESCRIPTION
Change `OrderingItem.__lt__(self, other)` to reflect to `type(other).__gt__(other, self)`, if `other` is not an instance of OrderingItem.