### PR TITLE
Add ability to directly replace elements in an Ordering

### DIFF
--- a/ordering/__init__.py
+++ b/ordering/__init__.py
@@ -61,6 +61,18 @@ class Ordering(Mapping[T, 'OrderingItem[T]']):
 
         return self._labels[left_item] < self._labels[right_item]
 
+    def replace(self, existing_item: T, new_item: T) -> None:
+        self.assert_contains(existing_item)
+        if existing_item != new_item:
+            self.assert_new_item(new_item)
+
+            self._successors[self._predecessors[existing_item]] = \
+            self._predecessors[self._successors[existing_item]] = new_item
+
+            self._successors[new_item] = self._successors.pop(existing_item)
+            self._predecessors[new_item] = self._predecessors.pop(existing_item)
+            self._labels[new_item] = self._labels.pop(existing_item)
+
     def __contains__(self, item: _T) -> bool:
         if isinstance(item, OrderingItem):
             return item.item in self._labels

--- a/tests/test_replacement.py
+++ b/tests/test_replacement.py
@@ -1,0 +1,68 @@
+from unittest import TestCase
+from itertools import combinations
+
+from ordering import Ordering
+
+
+class TestOrderingReplacement(TestCase):
+    items_list = [0], [1, 0], [2, 0, 1]
+    absent_list = 1, 2, 3
+
+    def test_basic_replace(self) -> None:
+        ordering = Ordering[int]((1, 0))
+
+        ordering.replace(0, 42)
+        self.assertNotIn(0, ordering)
+        self.assertListEqual(list(ordering), [1, 42])
+        ordering.replace(42, 0)
+        self.assertNotIn(42, ordering)
+        self.assertListEqual(list(ordering), [1, 0])
+
+    def test_replace_same(self) -> None:
+        for items in self.items_list:
+            ordering = Ordering[int](items)
+            for item in items:
+                with self.subTest(items=items, item=item):
+                    ordering.replace(item, item)
+                    self.assertListEqual(list(ordering), items)
+
+    def test_replace_len(self) -> None:
+        for items, absent in zip(self.items_list, self.absent_list):
+            for item in items:
+                with self.subTest(items=items, existing=item, new=item):
+                    ordering = Ordering[int](items)
+                    ordering.replace(item, item)
+                    self.assertEqual(len(ordering), len(items))
+
+                with self.subTest(items=items, existing=item, new=absent):
+                    ordering = Ordering[int](items)
+                    ordering.replace(item, absent)
+                    self.assertEqual(len(ordering), len(items))
+
+    def test_replace_raises(self) -> None:
+        absent_exc_re = 'does not contain'
+        duplicate_exc_re = 'already contains'
+
+        absent = 0
+        with self.subTest(items=(), existing=absent, new=absent):
+            with self.assertRaises(KeyError):
+                ordering = Ordering[int](())
+                ordering.replace(absent, absent)
+
+        for items, absent in zip(self.items_list, self.absent_list):
+            with self.subTest(items=items, existing=absent, new=absent):
+                with self.assertRaisesRegex(KeyError, absent_exc_re):
+                    ordering = Ordering[int](items)
+                    ordering.replace(absent, absent)
+
+            for a, b in combinations(items, 2):
+                with self.subTest(items=items, existing=a, new=b):
+                    with self.assertRaisesRegex(KeyError, duplicate_exc_re):
+                        ordering = Ordering[int](items)
+                        ordering.replace(a, b)
+
+            for item in items:
+                with self.subTest(items=items, existing=absent, new=item):
+                    with self.assertRaisesRegex(KeyError, absent_exc_re):
+                        ordering = Ordering[int](items)
+                        ordering.replace(absent, item)


### PR DESCRIPTION
Add `Ordering.replace` method to replace an existing element of an Ordering with a new (absent) element.

Add unit tests for replacing elements of an Ordering.