### PR TITLE
Add ability to swap the position of two elements in an Ordering

### DIFF
--- a/ordering/__init__.py
+++ b/ordering/__init__.py
@@ -1,6 +1,6 @@
 from fractions import Fraction
 from functools import total_ordering
-from typing import Dict, Generic, Iterable, Iterator, List, Mapping, TypeVar, Union
+from typing import Dict, Generic, Iterable, Iterator, List, Mapping, Tuple, TypeVar, Union
 
 from .utils import pairs
 
@@ -60,6 +60,26 @@ class Ordering(Mapping[T, 'OrderingItem[T]']):
         self.assert_contains(right_item)
 
         return self._labels[left_item] < self._labels[right_item]
+
+    def swap(self, item: T, other: T) -> None:
+        lower, upper = (item, other) if self.compare(item, other) else (other, item)
+        if item == other:
+            return
+
+        self._labels[item], self._labels[other] = self._labels[other], self._labels[item]
+        successors, predecessors = self._successors, self._predecessors
+
+        new_orders: Tuple[Tuple[_T, ...], ...]
+        if successors[lower] == upper:  # swapping two adjacent items
+            new_orders = (predecessors[lower], upper, lower, successors[upper]),
+        else:
+            new_orders = ((predecessors[item], other, successors[item]),
+                          (predecessors[other], item, successors[other]))
+
+        for order in new_orders:
+            for a, b in zip(order, order[1:]):
+                successors[a] = b
+                predecessors[b] = a
 
     def __contains__(self, item: _T) -> bool:
         if isinstance(item, OrderingItem):

--- a/tests/test_swapping.py
+++ b/tests/test_swapping.py
@@ -1,0 +1,45 @@
+from unittest import TestCase
+from itertools import combinations, combinations_with_replacement as combinations_w_r
+
+from ordering import Ordering
+
+
+class TestOrderingSwapping(TestCase):
+    items = (2, 0, 1)
+    absents = (5, 7)
+
+    def test_swap_two_existing_items(self) -> None:
+        for (ai, a), (bi, b) in combinations_w_r(enumerate(self.items), 2):
+            with self.subTest(a=a, b=b):
+                ordering = Ordering[int](self.items)
+                ordering.swap(a, b)
+                items_copy = list(self.items)
+                items_copy[ai], items_copy[bi] = items_copy[bi], items_copy[ai]
+                self.assertListEqual(list(ordering), items_copy)
+
+    def test_swap_commutativity(self) -> None:
+        for a, b in combinations(self.items, 2):
+            with self.subTest(a=a, b=b):
+                ordering_ab = Ordering[int](self.items)
+                ordering_ab.swap(a, b)
+                ordering_ba = Ordering[int](self.items)
+                ordering_ba.swap(b, a)
+                self.assertListEqual(list(ordering_ab), list(ordering_ba))
+
+    def test_swap_existing_with_absent_raises(self) -> None:
+        absent_exc_re = 'Ordering.+does not contain'
+
+        for item in self.items:
+            with self.subTest(item=item, other=self.absents[0]):
+                ordering = Ordering[int](self.items)
+                with self.assertRaisesRegex(KeyError, absent_exc_re):
+                    ordering.swap(item, self.absents[0])
+                with self.assertRaisesRegex(KeyError, absent_exc_re):
+                    ordering.swap(self.absents[0], item)
+
+    def test_swap_two_absent_items_raises(self) -> None:
+        for absent in self.absents:
+            with self.subTest(item=absent, other=self.absents[0]):
+                ordering = Ordering[int](self.items)
+                with self.assertRaisesRegex(KeyError, 'Ordering.+does not contain'):
+                    ordering.swap(absent, self.absents[0])


### PR DESCRIPTION
Add `Ordering.swap` method to swap the order of two given elements contained within an Ordering.

Add unit tests for swapping items of an Ordering.